### PR TITLE
Fix startup on raspberry pi

### DIFF
--- a/torrserver/rootfs/run.sh
+++ b/torrserver/rootfs/run.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/with-contenv bashio
 
-declare -A ARCH_MAP="( [armv7]=arm7 [amd64]=amd64 [i386]=386 )"
+echo "Prepare download"
+echo "Build arch: ${BUILD_ARCH}"
+
+declare -A ARCH_MAP="( [armv7]=arm7 [amd64]=amd64 [i386]=386 [aarch64]=arm64 )"
 
 TS_SOURCE="TorrServer-linux-${ARCH_MAP[${BUILD_ARCH}]}"
 TS_URL="https://github.com/YouROK/TorrServer/releases/latest/download/${TS_SOURCE}"


### PR DESCRIPTION
For some reason `BUILD_ARCH` in actual version of home assistant on raspberry pi matched as `aarch64`.
I added handling it in run code of add-on. Also add some useful logs to indicate plugin actually works.

Resolves #1 