### PR TITLE
[WiP] Expose DLNA-server port 9080

### DIFF
--- a/torrserver/config.yaml
+++ b/torrserver/config.yaml
@@ -34,7 +34,9 @@ ingress: true
 ingress_port: 8090
 ports:
   8090/tcp: 8090
+  9080/tcp: 9080
 ports_description:
   8090/tcp: TorrServer port
+  9080/tcp: DLNA-server port
 startup: system
 panel_icon: mdi:movie

--- a/torrserver/config.yaml
+++ b/torrserver/config.yaml
@@ -32,6 +32,7 @@ schema:
   m3u_custom_host: "str?"
 ingress: true
 ingress_port: 8090
+host_network: true
 ports:
   8090/tcp: 8090
   9080/tcp: 9080


### PR DESCRIPTION
A quick&dirty fix for https://github.com/aatrubilin/hassio-torrserver/issues/74
Now DLNA server is visible in my local network
I bet there's a better and more beautiful solution so marked this PR as a WiP