### PR TITLE
chore: update TorrServer to MatriX.143

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
           VERSION_ADDON=$(echo $VERSION | cut -d "-" -f 1)
           VERSION_TS=$(echo $VERSION | cut -d "-" -f 2)
           VERSION_META=$(echo $VERSION | cut -d "-" -f 3)
-          REPO=${GITHUB_REPOSITORY}
+          REPO=${GITHUB_REPOSITORY,,}
           echo "Version: ${VERSION}"
           echo "Version ts: ${VERSION_TS}"
           echo "Version meta: ${VERSION_META}"

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,3 +1,3 @@
 name: TorrServer app for Home Assistant
-url: "https://github.com/aatrubilin/hassio-torrserver"
+url: "https://github.com/Loncaster/hassio-torrserver"
 maintainer: Aleksandr Trubilin <aatrubilin@gmail.com>

--- a/torrserver/.build/customize/server/web/api/m3u.go
+++ b/torrserver/.build/customize/server/web/api/m3u.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -94,6 +95,7 @@ func allPlayList(c *gin.Context) {
 func playList(c *gin.Context) {
 	hash, _ := c.GetQuery("hash")
 	_, fromlast := c.GetQuery("fromlast")
+	index := c.Query("index")
 	if hash == "" {
 		c.AbortWithError(http.StatusBadRequest, errors.New("hash is empty"))
 		return
@@ -114,7 +116,7 @@ func playList(c *gin.Context) {
 	}
 
 	host := utils.GetScheme(c) + "://" + utils.GetHost(c)
-	list := getM3uList(tor.Status(), host, fromlast)
+	list := getM3uList(tor.Status(), host, fromlast, index)
 	list = "#EXTM3U\n" + list
 	name := strings.ReplaceAll(c.Param("fname"), `/`, "") // strip starting / from param
 	if name == "" {
@@ -140,17 +142,24 @@ func sendM3U(c *gin.Context, name, hash string, m3u string) {
 	http.ServeContent(c.Writer, c.Request, name, time.Now(), bytes.NewReader([]byte(m3u)))
 }
 
-func getM3uList(tor *state.TorrentStatus, host string, fromLast bool) string {
-    var customHost string
-    var ok bool
-    customHost, ok = os.LookupEnv("M3U_CUSTOM_HOST")
-    if ok {
-        host = customHost
-    }
+func getM3uList(tor *state.TorrentStatus, host string, fromLast bool, startIndex string) string {
+	if customHost, ok := os.LookupEnv("M3U_CUSTOM_HOST"); ok {
+		host = customHost
+	}
 
 	m3u := ""
 	from := 0
-	if fromLast {
+	if startIndex != "" {
+		id, err := strconv.Atoi(startIndex)
+		if err == nil {
+			for i, f := range tor.FileStats {
+				if f.Id == id {
+					from = i
+					break
+				}
+			}
+		}
+	} else if fromLast {
 		pos := searchLastPlayed(tor)
 		if pos != -1 {
 			from = pos

--- a/torrserver/CHANGELOG.md
+++ b/torrserver/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.1-MatriX.143 [2026-08-18]
+
+### ✨ New features
+
+- 🕶 Upgraded TorrServer to **MatriX.143** (changes: [MatriX.143](https://github.com/YouROK/TorrServer/releases/tag/MatriX.143))
+
 ## 2.0.1-MatriX.142.2 [2026-07-21]
 
 ### ✨ New features

--- a/torrserver/config.yaml
+++ b/torrserver/config.yaml
@@ -2,9 +2,9 @@
 name: TorrServer
 slug: torrserver
 description: TorrServer for home assistant
-image: ghcr.io/aatrubilin/hassio-torrserver/{arch}
+image: ghcr.io/loncaster/hassio-torrserver/{arch}
 version: 2.0.1-MatriX.143
-url: https://github.com/aatrubilin/hassio-torrserver
+url: https://github.com/Loncaster/hassio-torrserver
 init: false
 auth_api: true
 arch:

--- a/torrserver/config.yaml
+++ b/torrserver/config.yaml
@@ -3,7 +3,7 @@ name: TorrServer
 slug: torrserver
 description: TorrServer for home assistant
 image: ghcr.io/aatrubilin/hassio-torrserver/{arch}
-version: 2.0.1-MatriX.142.2
+version: 2.0.1-MatriX.143
 url: https://github.com/aatrubilin/hassio-torrserver
 init: false
 auth_api: true


### PR DESCRIPTION
## Summary

- update the Home Assistant app to TorrServer `MatriX.143`
- add the release to the changelog
- rebase the custom M3U host override on `MatriX.143`, preserving the new playlist `index` support

## Validation

- built the release image for `linux/amd64`
- built the release image for `linux/arm64` with QEMU, matching the GitHub Actions workflow